### PR TITLE
fix: Chromatic yml 파일 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,17 +24,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout (push)
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: npm ci
 
       - name: Publish to Chromatic
         id: publish_chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN  }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build-storybook
           onlyChanged: true
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #69


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- Chromatic yml 파일 수정
  - 오류 메시지: `Found only one commit`  
  - 오류 원인: `이전 커밋의 스토리북 빌드`와 `이번 커밋의 스토리북 빌드`를 비교해서 어떤 스토리가 바뀌었는지 판단하는데, 
  Chromatic이 “이전 커밋”을 찾을 수 없어서 발생한 이슈
  - 해결 방법: `fetch-depth: 1`로 인해 히스토리를 1개 커밋만 가져오던 것을 `fetch-depth: 0`을 넣어서 “전체 히스토리”를 불러오는 것으로 수정
  <img width="595" height="297" alt="image" src="https://github.com/user-attachments/assets/d39d4126-14f1-4906-98c6-b9666b522409" />

## 📸 스크린샷 (선택)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.