### PR TITLE
fix: 순수 텍스트만 입력할 경우, 본문 내용이 안보이는 이슈 해결

### DIFF
--- a/src/components/Atoms/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/Atoms/LinkRenderer/LinkRenderer.tsx
@@ -8,8 +8,12 @@ interface LinkRendererProps {
 }
 
 export const LinkRenderer = ({ text }: LinkRendererProps) => {
-  if (!text || !containsUrls(text)) {
+  if (!text) {
     return null;
+  }
+
+  if (!containsUrls(text)) {
+    return <div className="p-2 text-gray-700">{text}</div>;
   }
 
   const urls = extractUrls(text);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #221


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 순수 텍스트만 입력할 경우, 본문 내용이 안보이는 이슈 해결
(순수 텍스트만 입력할 때 null을 반환하던 이슈는 해결했어요)


## 📸 스크린샷 (선택)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.