### PR TITLE
feat: `장보기` 목록, 상세페이지에 태그 기능 구현 및 `소분하기` 목록 페이지에 반응형 구현

### DIFF
--- a/src/app/mypage/components/MeetingCard.tsx
+++ b/src/app/mypage/components/MeetingCard.tsx
@@ -115,9 +115,7 @@ export const MeetingCard = ({
   return (
     <div className="w-[calc(33.333%-21.33px)] flex-shrink-0">
       <Card
-        width="100%"
-        height="384px"
-        className="cursor-pointer overflow-hidden bg-white"
+        className="h-[384px] w-full cursor-pointer overflow-hidden bg-white"
         onClick={handleCardClick}
       >
         <CardContent>

--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -83,7 +83,7 @@ export const SharingListSection = ({
 
   return (
     <>
-      <div className="grid grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-8 lg:grid-cols-3 lg:gap-x-8 lg:gap-y-10">
         {dividingList.pages
           .flatMap((page) => page.content)
           .map((dividing) => (

--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -93,8 +93,12 @@ export const SharingListSection = ({
               className="cursor-pointer"
             >
               <CardContent>
-                <StatusTag status={dividing.status} />
-                {/* <BookmarkButton
+                <div className="relative mb-5">
+                  <StatusTag
+                    status={dividing.status}
+                    className="absolute top-3 left-3 z-10"
+                  />
+                  {/* <BookmarkButton
                   className="absolute top-4 right-0"
                   liked={dividing.bookmarked}
                   onChange={() =>
@@ -104,19 +108,20 @@ export const SharingListSection = ({
                     )
                   }
                 /> */}
-                <CardImage
-                  alt="기본 카드"
-                  src={
-                    !dividing.image ||
-                    (Array.isArray(dividing.image) &&
-                      dividing.image.length === 0) ||
-                    (typeof dividing.image === 'string' &&
-                      dividing.image.includes('example'))
-                      ? '/images/notFound_image.png'
-                      : dividing.image
-                  }
-                  className="border-gray-10 bg-gray-5 mb-5 h-[200px] w-full rounded-lg border-1"
-                />
+                  <CardImage
+                    alt="기본 카드"
+                    src={
+                      !dividing.image ||
+                      (Array.isArray(dividing.image) &&
+                        dividing.image.length === 0) ||
+                      (typeof dividing.image === 'string' &&
+                        dividing.image.includes('example'))
+                        ? '/images/notFound_image.png'
+                        : dividing.image
+                    }
+                    className="border-gray-10 bg-gray-5 h-[200px] w-full rounded-lg border-1"
+                  />
+                </div>
                 <div className="flex flex-col gap-2">
                   <CardTitle className="font-memomentKkukkkuk line-clamp-1">
                     {dividing.item}

--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -8,7 +8,7 @@ import {
   CardImage,
   CardSubtitle,
   CardTitle,
-  BookmarkButton,
+  // BookmarkButton,
   Line,
   StatusTag,
 } from '@/components';
@@ -16,7 +16,7 @@ import { MapPin } from 'lucide-react';
 import { DividingMeetingsType } from '@/types/meetingsType';
 import { timeFormatter } from '@/utils';
 import { NonDividingList } from './NonDividingList';
-import { useBookmark } from '@/hooks';
+// import { useBookmark } from '@/hooks';
 import { useInfiniteScrollTrigger } from '@/hooks/useScroll';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getDividingListApi } from '@/apis/meetings/getDividingListApi';
@@ -30,7 +30,7 @@ export const SharingListSection = ({
   initialDividingList: DividingMeetingsType | null;
 }) => {
   const router = useRouter();
-  const { handleBookmark } = useBookmark();
+  // const { handleBookmark } = useBookmark();
   const { isBottom } = useInfiniteScrollTrigger();
 
   const {
@@ -93,11 +93,8 @@ export const SharingListSection = ({
               className="cursor-pointer"
             >
               <CardContent>
-                <StatusTag
-                  status={dividing.status}
-                  className="absolute top-3 left-3"
-                />
-                <BookmarkButton
+                <StatusTag status={dividing.status} />
+                {/* <BookmarkButton
                   className="absolute top-4 right-0"
                   liked={dividing.bookmarked}
                   onChange={() =>
@@ -106,7 +103,7 @@ export const SharingListSection = ({
                       dividing.bookmarked,
                     )
                   }
-                />
+                /> */}
                 <CardImage
                   alt="기본 카드"
                   src={
@@ -118,21 +115,22 @@ export const SharingListSection = ({
                       ? '/images/notFound_image.png'
                       : dividing.image
                   }
-                  className="border-gray-10 bg-gray-5 h-[200px] w-full rounded-lg border-1"
+                  className="border-gray-10 bg-gray-5 mb-5 h-[200px] w-full rounded-lg border-1"
                 />
-
-                <CardTitle className="font-memomentKkukkkuk line-clamp-1">
-                  {dividing.item}
-                </CardTitle>
-                <CardSubtitle className="text-text-sub2 flex items-center gap-1 text-sm">
-                  <span>{dividing.user.userName}</span>
-                  <span>・</span>
-                  <span>{timeFormatter(dividing.createdAt)}</span>
-                </CardSubtitle>
+                <div className="flex flex-col gap-2">
+                  <CardTitle className="font-memomentKkukkkuk line-clamp-1">
+                    {dividing.item}
+                  </CardTitle>
+                  <CardSubtitle className="text-text-sub2 flex items-center gap-1 text-sm">
+                    <span>{dividing.user.userName}</span>
+                    <span>・</span>
+                    <span>{timeFormatter(dividing.createdAt)}</span>
+                  </CardSubtitle>
+                </div>
               </CardContent>
-              <Line />
+              <Line className="mt-3 mb-3" />
               <CardFooter>
-                <div className="mb-2 flex items-center gap-1 text-sm">
+                <div className="flex items-center gap-1 text-sm">
                   <MapPin className="text-gray-40 size-4" />
                   <p>{dividing.location.detail}</p>
                 </div>

--- a/src/app/shopping/components/HashTag.tsx
+++ b/src/app/shopping/components/HashTag.tsx
@@ -1,6 +1,12 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 export const HashTag = ({ tags }: { tags: string[] }) => {
+  const router = useRouter();
+
   const handleTagClick = (tag: string) => {
-    console.log(tag);
+    router.push(`/shopping?tag=${encodeURIComponent(tag)}`);
   };
 
   return (

--- a/src/app/shopping/components/HashTag.tsx
+++ b/src/app/shopping/components/HashTag.tsx
@@ -1,0 +1,19 @@
+export const HashTag = ({ tags }: { tags: string[] }) => {
+  const handleTagClick = (tag: string) => {
+    console.log(tag);
+  };
+
+  return (
+    <>
+      {tags.map((tag) => (
+        <span
+          className="text-primary cursor-pointer text-sm font-medium hover:underline"
+          onClick={() => handleTagClick(tag)}
+          key={tag}
+        >
+          {`# ${tag}`}
+        </span>
+      ))}
+    </>
+  );
+};

--- a/src/app/shopping/components/HashTag.tsx
+++ b/src/app/shopping/components/HashTag.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { cn } from '@/utils/cn';
 
-export const HashTag = ({ tags }: { tags: string[] }) => {
+export const HashTag = ({
+  tags,
+  className,
+}: {
+  tags: string[];
+  className?: string;
+}) => {
   const router = useRouter();
 
   const handleTagClick = (tag: string) => {
@@ -13,7 +20,10 @@ export const HashTag = ({ tags }: { tags: string[] }) => {
     <>
       {tags.map((tag) => (
         <span
-          className="text-primary cursor-pointer text-sm font-medium hover:underline"
+          className={cn(
+            'text-primary cursor-pointer text-sm font-medium',
+            className,
+          )}
           onClick={() => handleTagClick(tag)}
           key={tag}
         >

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -101,8 +101,6 @@ export const ShoppingListSection = ({
             <Card
               key={shopping.id}
               className="border-gray-10 flex cursor-pointer flex-col gap-3 rounded-xl border p-6"
-              height="auto"
-              width="auto"
               onClick={() => onClickCard(shopping.id.toString())}
             >
               <StatusTag status={shopping.status} />

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -24,9 +24,7 @@ import { useSearchParams } from 'next/navigation';
 
 export const ShoppingListSection = ({
   initialShoppingList,
-  query: initialQuery,
 }: {
-  query: URLSearchParams;
   initialShoppingList: ShoppingMeetingsType | null;
 }) => {
   const router = useRouter();

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -100,17 +100,13 @@ export const ShoppingListSection = ({
           .map((shopping) => (
             <Card
               key={shopping.id}
-              className="border-gray-10 cursor-pointer rounded-xl border p-6"
+              className="border-gray-10 flex cursor-pointer flex-col gap-3 rounded-xl border p-6"
               height="auto"
               width="auto"
               onClick={() => onClickCard(shopping.id.toString())}
             >
-              <CardContent className="pt-16">
-                <StatusTag
-                  status={shopping.status}
-                  className="absolute top-0 left-0"
-                />
-
+              <StatusTag status={shopping.status} />
+              <CardContent className="flex flex-col gap-3">
                 {/* <BookmarkButton
                   className="absolute top-[4px] right-0"
                   liked={shopping.bookmarked}
@@ -126,15 +122,15 @@ export const ShoppingListSection = ({
                   <span>・</span>
                   <span>{timeFormatter(shopping.createdAt)}</span>
                 </CardSubtitle>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-x-2">
                   {shopping.tags && shopping.tags.length > 0 && (
                     <HashTag tags={shopping.tags} />
                   )}
                 </div>
               </CardContent>
-              <Line className="mt-6" />
+              <Line />
               <CardFooter className="text-text-sub2 text-sm">
-                <div className="mb-2 flex items-center gap-1 text-sm">
+                <div className="flex items-center gap-1 text-sm">
                   <MapPin className="size-4" />
                   <p>{shopping.location.district}</p>
                 </div>

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -6,7 +6,7 @@ import {
   CardFooter,
   CardSubtitle,
   CardTitle,
-  BookmarkButton,
+  // BookmarkButton,
   Line,
   StatusTag,
 } from '@/components';
@@ -15,7 +15,7 @@ import { timeFormatter } from '@/utils';
 import { MapPin } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { NonShoppingList } from './NonShoppingList';
-import { useBookmark } from '@/hooks';
+// import { useBookmark } from '@/hooks';
 import { useEffect } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getShoppingListApi } from '@/apis/meetings/getShoppingListApi';
@@ -29,7 +29,7 @@ export const ShoppingListSection = ({
   initialShoppingList: ShoppingMeetingsType | null;
 }) => {
   const router = useRouter();
-  const { handleBookmark } = useBookmark();
+  // const { handleBookmark } = useBookmark();
   const { isBottom } = useInfiniteScrollTrigger();
   const searchParams = useSearchParams();
 
@@ -111,13 +111,13 @@ export const ShoppingListSection = ({
                   className="absolute top-0 left-0"
                 />
 
-                <BookmarkButton
+                {/* <BookmarkButton
                   className="absolute top-[4px] right-0"
                   liked={shopping.bookmarked}
                   onChange={() =>
                     handleBookmark(shopping.id.toString(), shopping.bookmarked)
                   }
-                />
+                /> */}
                 <CardTitle className="font-memomentKkukkkuk line-clamp-2">
                   {shopping.title}
                 </CardTitle>

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -21,6 +21,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getShoppingListApi } from '@/apis/meetings/getShoppingListApi';
 import { useInfiniteScrollTrigger } from '@/hooks/useScroll';
 import { useSearchParams } from 'next/navigation';
+import { HashTag } from './HashTag';
 
 export const ShoppingListSection = ({
   initialShoppingList,
@@ -125,6 +126,11 @@ export const ShoppingListSection = ({
                   <span>・</span>
                   <span>{timeFormatter(shopping.createdAt)}</span>
                 </CardSubtitle>
+                <div className="flex flex-wrap gap-2">
+                  {shopping.tags && shopping.tags.length > 0 && (
+                    <HashTag tags={shopping.tags} />
+                  )}
+                </div>
               </CardContent>
               <Line className="mt-6" />
               <CardFooter className="text-text-sub2 text-sm">

--- a/src/app/shopping/components/ShoppingTagsSection.tsx
+++ b/src/app/shopping/components/ShoppingTagsSection.tsx
@@ -39,12 +39,14 @@ export const ShoppingTagsSection = () => {
 
   return (
     <div className="flex flex-wrap justify-center gap-2">
-      <KeywordChip
-        label="전체"
-        variant={activeTag === '' ? 'active' : 'inactive'}
-        aria-label="전체"
-        onClick={() => handleTagClick('')}
-      />
+      {popularTags.length > 0 && (
+        <KeywordChip
+          label="전체"
+          variant={activeTag === '' ? 'active' : 'inactive'}
+          aria-label="전체"
+          onClick={() => handleTagClick('')}
+        />
+      )}
       {popularTags.map((tag, index) => (
         <KeywordChip
           key={index}

--- a/src/app/shopping/components/UpdateShoppingForm.tsx
+++ b/src/app/shopping/components/UpdateShoppingForm.tsx
@@ -90,12 +90,7 @@ export function UpdateShoppingForm({
 
   useEffect(() => {
     if (meetingDetail) {
-      console.log('meetingDetail:', meetingDetail);
-      console.log('tags:', meetingDetail.tags);
-      console.log('category:', meetingDetail.category);
-
       const existingTags = meetingDetail.tags || [];
-      console.log('existingTags:', existingTags);
 
       reset({
         title: meetingDetail.title || '',
@@ -124,10 +119,8 @@ export function UpdateShoppingForm({
         setTimeout(() => {
           setValue('tags', existingTags);
           clearErrors('tags');
-          console.log('태그 설정됨:', existingTags);
         }, 100);
       } else {
-        console.log('태그 데이터가 없음');
       }
     }
   }, [meetingDetail, reset, setValue, clearErrors]);
@@ -165,19 +158,14 @@ export function UpdateShoppingForm({
   };
 
   const handleTagClick = (tagValue: string) => {
-    console.log('태그 클릭됨:', tagValue);
     const currentTags = watch('tags');
-    console.log('현재 태그들:', currentTags);
     const isSelected = currentTags.includes(tagValue);
-    console.log('선택된 상태:', isSelected);
 
     if (isSelected) {
       const newTags = currentTags.filter((t) => t !== tagValue);
-      console.log('태그 제거 후:', newTags);
       setValue('tags', newTags);
     } else {
       const newTags = [...currentTags, tagValue];
-      console.log('태그 추가 후:', newTags);
       setValue('tags', newTags);
     }
     clearErrors('tags');
@@ -241,9 +229,7 @@ export function UpdateShoppingForm({
             <div className="mt-3 flex flex-wrap gap-2">
               {SHOPPING_TAGS.map((tag) => {
                 const isSelected = watch('tags').includes(tag.value);
-                console.log(
-                  `태그 ${tag.value}: 선택됨=${isSelected}, 현재 tags=${JSON.stringify(watch('tags'))}`,
-                );
+
                 return (
                   <KeywordChip
                     key={tag.value}

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -67,10 +67,7 @@ export default async function ShoppingPage({
       <section className="flex flex-col gap-6">
         <ShoppingTagsSection />
         <FilterSection />
-        <ShoppingListSection
-          initialShoppingList={initialShoppingList}
-          query={query}
-        />
+        <ShoppingListSection initialShoppingList={initialShoppingList} />
       </section>
       <SideButtonSection />
     </main>

--- a/src/components/Atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Atoms/Checkbox/Checkbox.stories.tsx
@@ -56,7 +56,6 @@ export const CheckboxWithForm: Story = {
 
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      console.log('체크 상태:', checked);
     };
 
     return (

--- a/src/components/Atoms/StatusTag/StatusTag.test.tsx
+++ b/src/components/Atoms/StatusTag/StatusTag.test.tsx
@@ -2,11 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { StatusTag } from './StatusTag';
 
 describe('StatusTag 컴포넌트', () => {
-  test('div 엘리먼트로 렌더링되어야 한다', () => {
+  test('span 엘리먼트로 렌더링되어야 한다', () => {
     render(<StatusTag status="RECRUITING" />);
     const tag = screen.getByRole('status');
     expect(tag).toBeInTheDocument();
-    expect(tag.nodeName).toBe('DIV');
+    expect(tag.nodeName).toBe('SPAN');
   });
 
   describe('status prop', () => {
@@ -30,25 +30,25 @@ describe('StatusTag 컴포넌트', () => {
     test('RECRUITING 상태일 때 올바른 스타일이 적용되어야 한다', () => {
       render(<StatusTag status="RECRUITING" />);
       const tag = screen.getByRole('status');
-      expect(tag).toHaveClass('bg-[var(--GreenScale-Green1)]');
-      expect(tag).toHaveClass('border-[var(--Keycolor-primary)]');
-      expect(tag).toHaveClass('text-[var(--Keycolor-primary)]');
+      expect(tag).toHaveClass('bg-Green-1');
+      expect(tag).toHaveClass('border-primary');
+      expect(tag).toHaveClass('text-primary');
     });
 
     test('COMPLETED 상태일 때 올바른 스타일이 적용되어야 한다', () => {
       render(<StatusTag status="COMPLETED" />);
       const tag = screen.getByRole('status');
       expect(tag).toHaveClass('bg-[var(--GrayScale-Gray5)]');
-      expect(tag).toHaveClass('border-[var(--text-inactive)]');
-      expect(tag).toHaveClass('text-[var(--text-sub2)]');
+      expect(tag).toHaveClass('border-text-inactive');
+      expect(tag).toHaveClass('text-text-sub2');
     });
 
     test('CLOSED 상태일 때 올바른 스타일이 적용되어야 한다', () => {
       render(<StatusTag status="CLOSED" />);
       const tag = screen.getByRole('status');
       expect(tag).toHaveClass('bg-[var(--GrayScale-Gray5)]');
-      expect(tag).toHaveClass('border-[var(--text-inactive)]');
-      expect(tag).toHaveClass('text-[var(--text-sub2)]');
+      expect(tag).toHaveClass('border-text-inactive');
+      expect(tag).toHaveClass('text-text-sub2');
     });
   });
 
@@ -56,10 +56,6 @@ describe('StatusTag 컴포넌트', () => {
     test('공통 스타일이 적용되어야 한다', () => {
       render(<StatusTag status="RECRUITING" />);
       const tag = screen.getByRole('status');
-      expect(tag).toHaveClass('mx-auto');
-      expect(tag).toHaveClass('flex');
-      expect(tag).toHaveClass('items-center');
-      expect(tag).toHaveClass('justify-center');
       expect(tag).toHaveClass('rounded-3xl');
       expect(tag).toHaveClass('border');
       expect(tag).toHaveClass('px-3');
@@ -80,7 +76,6 @@ describe('StatusTag 컴포넌트', () => {
       render(<StatusTag status="RECRUITING" className="bg-red-500" />);
       const tag = screen.getByRole('status');
       expect(tag).toHaveClass('bg-red-500');
-      expect(tag).toHaveClass('flex');
       expect(tag).toHaveClass('rounded-3xl');
     });
   });

--- a/src/components/Atoms/StatusTag/StatusTag.tsx
+++ b/src/components/Atoms/StatusTag/StatusTag.tsx
@@ -13,31 +13,27 @@ const STATUS_LABEL: Record<StatusTagProps['status'], string> = {
 };
 
 const STATUS_STYLE: Record<StatusTagProps['status'], string> = {
-  RECRUITING:
-    'bg-[var(--GreenScale-Green1)] border-[var(--Keycolor-primary)] text-[var(--Keycolor-primary)]',
-  COMPLETED:
-    'bg-[var(--GrayScale-Gray5)] border-[var(--text-inactive)] text-[var(--text-sub2)]',
-  CLOSED:
-    'bg-[var(--GrayScale-Gray5)] border-[var(--text-inactive)] text-[var(--text-sub2)]',
-  ReviewOpen:
-    'bg-[var(--GreenScale-Green1)] border-[var(--Keycolor-primary)] text-[var(--Keycolor-primary)]',
+  RECRUITING: 'bg-Green-1 border-primary text-primary',
+  COMPLETED: 'bg-[var(--GrayScale-Gray5)] border-text-inactive text-text-sub2',
+  CLOSED: 'bg-[var(--GrayScale-Gray5)] border-text-inactive text-text-sub2',
+  ReviewOpen: 'bg-[var(--GreenScale-Green1)] border-primary text-primary',
   ReviewClosed:
-    'bg-[var(--GrayScale-Gray5)] border-[var(--text-inactive)] text-[var(--text-sub2)]',
+    'bg-[var(--GrayScale-Gray5)] border-[var(--text-inactive)] text-text-sub2',
 };
 
 export const StatusTag = ({ status, className, ...props }: StatusTagProps) => {
   return (
-    <div
+    <span
       role="status"
       aria-label={`${STATUS_LABEL[status]} 상태`}
       className={cn(
-        'mx-auto flex items-center justify-center rounded-3xl border px-3 py-1.5 text-sm font-medium',
+        'w-fit rounded-3xl border px-3 py-1.5 text-sm font-medium',
         STATUS_STYLE[status],
         className,
       )}
       {...props}
     >
       {STATUS_LABEL[status]}
-    </div>
+    </span>
   );
 };

--- a/src/components/Molecules/Card/Card.stories.tsx
+++ b/src/components/Molecules/Card/Card.stories.tsx
@@ -14,17 +14,13 @@ const meta = {
   title: 'Molecules/Card',
   component: Card,
   args: {
-    width: '376px',
-    height: '306px',
-    className: '',
+    className: 'w-[376px] h-[306px]',
   },
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {
-    width: { control: 'text', description: '카드의 너비 px' },
-    height: { control: 'text', description: '카드의 높이 px' },
     className: { control: 'text', description: '카드의 클래스명' },
   },
 } satisfies Meta<typeof Card>;

--- a/src/components/Molecules/Card/Card.stories.tsx
+++ b/src/components/Molecules/Card/Card.stories.tsx
@@ -51,10 +51,7 @@ export const BookmarkButtonCard: Story = {
   render: (args) => (
     <Card {...args}>
       <CardContent>
-        <BookmarkButton
-          liked={false}
-          onChange={(liked) => console.log(liked)}
-        />
+        <BookmarkButton liked={false} />
         <CardImage src="https://placehold.co/300x200" alt="기본 카드" />
         <CardTitle className="font-memomentKkukkkuk">Card Title</CardTitle>
         <CardSubtitle>Card Subtitle</CardSubtitle>
@@ -87,10 +84,7 @@ export const CustomCard: Story = {
   render: (args) => (
     <Card {...args}>
       <CardContent>
-        <BookmarkButton
-          liked={false}
-          onChange={(liked) => console.log(liked)}
-        />
+        <BookmarkButton liked={false} />
         <CardImage src="https://placehold.co/300x200" alt="기본 카드" />
         <CardTitle className="font-memomentKkukkkuk">Card Title</CardTitle>
         <CardSubtitle>Card Subtitle</CardSubtitle>

--- a/src/components/Molecules/Card/Card.tsx
+++ b/src/components/Molecules/Card/Card.tsx
@@ -9,9 +9,7 @@ interface cardContentProps {
   children?: React.ReactNode;
 }
 
-export interface cardProps extends cardContentProps {
-  width?: string;
-  height?: string;
+export interface CardProps extends cardContentProps {
   onClick?: () => void;
   href?: string;
 }
@@ -59,32 +57,17 @@ const BookmarkButtonComponent = memo(
 BookmarkButtonComponent.displayName = 'BookmarkButton';
 export const BookmarkButton = BookmarkButtonComponent;
 
-export const Card = ({
-  className,
-  children,
-  width = '306px',
-  height = '376px',
-  onClick,
-  href,
-}: cardProps) => {
+export const Card = ({ className, children, onClick, href }: CardProps) => {
   if (href) {
     return (
-      <a
-        href={href}
-        className={`${className} block select-none`}
-        style={{ width: `${width}`, height: `${height}` }}
-      >
+      <a href={href} className={`${className} block select-none`}>
         {children}
       </a>
     );
   }
 
   return (
-    <div
-      className={`${className} select-none`}
-      style={{ width: `${width}`, height: `${height}` }}
-      onClick={onClick}
-    >
+    <div className={`${className} select-none`} onClick={onClick}>
       {children}
     </div>
   );

--- a/src/components/Molecules/Card/Card.tsx
+++ b/src/components/Molecules/Card/Card.tsx
@@ -104,9 +104,7 @@ export const CardImage = ({ className, src, alt }: cardImageProps) => {
 };
 
 export const CardTitle = ({ className, children }: cardContentProps) => {
-  return (
-    <h3 className={`${className} mb-2 text-2xl text-[#1a1a1a]`}>{children}</h3>
-  );
+  return <h3 className={`${className} text-2xl text-[#1a1a1a]`}>{children}</h3>;
 };
 
 export const CardSubtitle = ({ className, children }: cardContentProps) => {
@@ -122,9 +120,7 @@ export const CardFooter = ({ className, children }: cardContentProps) => {
 };
 
 export const Line = ({ className }: cardContentProps) => {
-  return (
-    <div className={`${className} mt-3 mb-5 h-[1px] w-full bg-gray-200`}></div>
-  );
+  return <div className={`${className} h-[1px] w-full bg-gray-200`}></div>;
 };
 
 interface mainCardProps {

--- a/src/components/Molecules/Card/Card.tsx
+++ b/src/components/Molecules/Card/Card.tsx
@@ -98,7 +98,7 @@ export const CardImage = ({ className, src, alt }: cardImageProps) => {
       alt={alt}
       width={276}
       height={200}
-      className={`${className} mb-5 h-[200px] w-full rounded-lg object-cover`}
+      className={`${className} h-[200px] w-full rounded-lg object-cover`}
     />
   );
 };

--- a/src/components/Molecules/Card/index.ts
+++ b/src/components/Molecules/Card/index.ts
@@ -7,4 +7,4 @@ export { CardTitle } from './Card';
 export { BookmarkButton } from './Card';
 export { Line } from './Card';
 export { MainCard } from './Card';
-export type { cardProps } from './Card';
+export type { CardProps } from './Card';

--- a/src/components/Molecules/index.ts
+++ b/src/components/Molecules/index.ts
@@ -8,7 +8,7 @@ export {
   BookmarkButton,
   Line,
   MainCard,
-  type cardProps,
+  type CardProps,
 } from './Card';
 export { Dropdown, type DropdownProps } from './Dropdown';
 export { Header } from './Header';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,7 +25,7 @@ export {
   BookmarkButton,
   Line,
   MainCard,
-  type cardProps,
+  type CardProps,
   Dropdown,
   type DropdownProps,
   Header,

--- a/src/components/marketplace/DetailAside/AsideHeader.tsx
+++ b/src/components/marketplace/DetailAside/AsideHeader.tsx
@@ -22,7 +22,7 @@ export const AsideHeader = ({
 
       {tags && tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          <HashTag tags={tags} />
+          <HashTag tags={tags} className="hover:underline" />
         </div>
       )}
     </div>

--- a/src/components/marketplace/DetailAside/AsideHeader.tsx
+++ b/src/components/marketplace/DetailAside/AsideHeader.tsx
@@ -1,4 +1,5 @@
 import { ProfileImg } from '@/components';
+import { HashTag } from '@/app/shopping/components/HashTag';
 
 export const AsideHeader = ({
   title,
@@ -21,9 +22,7 @@ export const AsideHeader = ({
 
       {tags && tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {tags.map((tag) => (
-            <span key={tag}>{tag}</span>
-          ))}
+          <HashTag tags={tags} />
         </div>
       )}
     </div>

--- a/src/components/marketplace/DetailAside/AsideHeader.tsx
+++ b/src/components/marketplace/DetailAside/AsideHeader.tsx
@@ -4,10 +4,12 @@ export const AsideHeader = ({
   title,
   profileImageUrl,
   userName,
+  tags,
 }: {
   title: string;
   profileImageUrl: string;
   userName: string;
+  tags?: string[];
 }) => {
   return (
     <div className="flex flex-col gap-3">
@@ -16,6 +18,14 @@ export const AsideHeader = ({
         <ProfileImg profileImageUrl={profileImageUrl} size={24} />
         <span className="text-text-sub2">{userName}</span>
       </div>
+
+      {tags && tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <span key={tag}>{tag}</span>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/marketplace/DetailAside/DetailAside.tsx
+++ b/src/components/marketplace/DetailAside/DetailAside.tsx
@@ -103,6 +103,7 @@ export const DetailAside = ({
         title={meetingDetail?.title}
         profileImageUrl={meetingDetail?.user.profile}
         userName={meetingDetail?.user.userName}
+        tags={meetingDetail?.tags}
       />
 
       <div className="bg-gray-10 h-[1px] w-full"></div>

--- a/src/types/meetingsType.ts
+++ b/src/types/meetingsType.ts
@@ -93,6 +93,7 @@ interface ShoppingContentType {
   currentMember: number;
   createdAt: string;
   bookmarked: boolean;
+  tags: string[];
 }
 
 /*


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #242, #243


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- `장보기` 목록, 상세페이지에 태그 기능 구현
  - 상세페이지에서 태그 클릭시 목록 페이지로 이동 및 태그 필터 기능 구현
- `소분하기` 목록 페이지에 반응형 구현
  -  우측의 필터 기능의 반응형은 고민이 더 필요해요
- 카드 컴포넌트 레이아웃 수정 (`margin`, `padding` >> `gap`으로 변경)
- 북마크 주석처리 (혹시 몰라 `삭제` 대신 `주석` 처리 했어요)
- 불필요한 `console.log` 삭제

## 📸 스크린샷 (선택)

### 태그 기능 구현

<img width="1547" height="790" alt="image" src="https://github.com/user-attachments/assets/b284124e-e7af-4793-b8eb-58803d3d5adc" />
<img width="1525" height="653" alt="image" src="https://github.com/user-attachments/assets/df424f90-b17a-44aa-ae44-ac8302b43832" />


### 소분하기 페이지 반응형 구현

<img width="768" height="539" alt="image" src="https://github.com/user-attachments/assets/a13ef29a-c911-4eec-a3e8-b8e60feaecf9" />

<img width="576" height="539" alt="image" src="https://github.com/user-attachments/assets/23aeaaab-2394-49ce-83e7-62f83cfdb791" />

<img width="421" height="517" alt="image" src="https://github.com/user-attachments/assets/daf5b16a-85cf-4723-8647-98bc80662fff" />




## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.