### PR TITLE
design: 모집완료 상태일 때 목록 페이지 카드 폰트 색상 변경

### DIFF
--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -123,7 +123,10 @@ export const SharingListSection = ({
                   />
                 </div>
                 <div className="flex flex-col gap-2">
-                  <CardTitle className="font-memomentKkukkkuk line-clamp-1">
+                  <CardTitle
+                    className="font-memomentKkukkkuk line-clamp-1"
+                    status={dividing.status as 'RECRUITING'}
+                  >
                     {dividing.item}
                   </CardTitle>
                   <CardSubtitle className="text-text-sub2 flex items-center gap-1 text-sm">

--- a/src/app/shopping/components/HashTag.tsx
+++ b/src/app/shopping/components/HashTag.tsx
@@ -6,9 +6,11 @@ import { cn } from '@/utils/cn';
 export const HashTag = ({
   tags,
   className,
+  status,
 }: {
   tags: string[];
   className?: string;
+  status?: 'RECRUITING';
 }) => {
   const router = useRouter();
 
@@ -21,7 +23,8 @@ export const HashTag = ({
       {tags.map((tag) => (
         <span
           className={cn(
-            'text-primary cursor-pointer text-sm font-medium',
+            'cursor-pointer text-sm font-medium',
+            status === 'RECRUITING' ? 'text-primary' : 'text-Green-30',
             className,
           )}
           onClick={() => handleTagClick(tag)}

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -112,7 +112,10 @@ export const ShoppingListSection = ({
                     handleBookmark(shopping.id.toString(), shopping.bookmarked)
                   }
                 /> */}
-                <CardTitle className="font-memomentKkukkkuk line-clamp-2">
+                <CardTitle
+                  className="font-memomentKkukkkuk line-clamp-2"
+                  status={shopping.status as 'RECRUITING'}
+                >
                   {shopping.title}
                 </CardTitle>
                 <CardSubtitle className="text-text-sub2 flex items-center gap-1 text-sm">
@@ -122,7 +125,10 @@ export const ShoppingListSection = ({
                 </CardSubtitle>
                 <div className="flex flex-wrap gap-x-2">
                   {shopping.tags && shopping.tags.length > 0 && (
-                    <HashTag tags={shopping.tags} />
+                    <HashTag
+                      tags={shopping.tags}
+                      status={shopping.status as 'RECRUITING'}
+                    />
                   )}
                 </div>
               </CardContent>

--- a/src/components/Molecules/Card/Card.tsx
+++ b/src/components/Molecules/Card/Card.tsx
@@ -3,6 +3,7 @@
 import { memo, useState, useEffect } from 'react';
 import Image from 'next/image';
 import { Bookmark } from 'lucide-react';
+import { cn } from '@/utils/cn';
 
 interface cardContentProps {
   className?: string;
@@ -86,8 +87,23 @@ export const CardImage = ({ className, src, alt }: cardImageProps) => {
   );
 };
 
-export const CardTitle = ({ className, children }: cardContentProps) => {
-  return <h3 className={`${className} text-2xl text-[#1a1a1a]`}>{children}</h3>;
+export const CardTitle = ({
+  className,
+  children,
+  status,
+}: cardContentProps & {
+  status?: 'RECRUITING';
+}) => {
+  return (
+    <h3
+      className={cn(
+        `${className} text-2xl`,
+        status === 'RECRUITING' ? 'text-text-main' : 'text-text-sub2',
+      )}
+    >
+      {children}
+    </h3>
+  );
 };
 
 export const CardSubtitle = ({ className, children }: cardContentProps) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #258


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 모집완료 상태일 때 목록 페이지 카드 폰트 색상 변경


## 📸 스크린샷 (선택)

### 장보기
<img width="466" height="288" alt="image" src="https://github.com/user-attachments/assets/8bf4a632-4d4d-4ecc-8079-72f0f274b1ad" />

### 소분하기
<img width="704" height="352" alt="image" src="https://github.com/user-attachments/assets/b112e76d-a5b1-475a-b75d-bc04f1be5a41" />



## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.