### PR TITLE
feat: 소분/장보기 모임 등록시 내 주소 불러오는 기능 구현

### DIFF
--- a/src/app/mypage/components/Card/MeetingDividingCard.tsx
+++ b/src/app/mypage/components/Card/MeetingDividingCard.tsx
@@ -116,7 +116,7 @@ export const MeetingDividingCard = ({
   return (
     <div className="flex-shrink-0">
       <Card
-        className="h-[529px] w-full cursor-pointer overflow-hidden bg-white"
+        className="w-full cursor-pointer overflow-hidden bg-white"
         onClick={handleCardClick}
       >
         <CardContent>
@@ -130,11 +130,11 @@ export const MeetingDividingCard = ({
               </div>
             </div>
             {/* 이미지 영역 */}
-            <div className="relative h-full w-full rounded-lg">
+            <div className="relative aspect-[3/2] w-full rounded-lg">
               <CardImage
                 src={meeting.thumbnailUrl}
                 alt={meeting.title}
-                className="h-full w-full object-cover"
+                className="absolute inset-0 h-full w-full object-cover"
               />
             </div>
           </div>

--- a/src/app/mypage/components/Card/MeetingDividingCard.tsx
+++ b/src/app/mypage/components/Card/MeetingDividingCard.tsx
@@ -130,11 +130,11 @@ export const MeetingDividingCard = ({
               </div>
             </div>
             {/* 이미지 영역 */}
-            <div className="relative aspect-[3/2] w-full rounded-lg">
+            <div className="border-gray-10 relative aspect-[3/2] w-full overflow-hidden rounded-lg border-1">
               <CardImage
                 src={meeting.thumbnailUrl}
                 alt={meeting.title}
-                className="absolute inset-0 h-full w-full object-cover"
+                className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 hover:scale-110"
               />
             </div>
           </div>

--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -112,19 +112,21 @@ export const SharingListSection = ({
                     status={dividing.status}
                     className="absolute top-3 left-3 z-10"
                   />
-                  <CardImage
-                    alt="기본 카드"
-                    src={
-                      !dividing.image ||
-                      (Array.isArray(dividing.image) &&
-                        dividing.image.length === 0) ||
-                      (typeof dividing.image === 'string' &&
-                        dividing.image.includes('example'))
-                        ? '/images/notFound_image.png'
-                        : dividing.image
-                    }
-                    className="h-[200px] w-full rounded-lg transition-transform duration-300 hover:scale-110"
-                  />
+                  <div className="relative aspect-[3/2] w-full">
+                    <CardImage
+                      alt="기본 카드"
+                      src={
+                        !dividing.image ||
+                        (Array.isArray(dividing.image) &&
+                          dividing.image.length === 0) ||
+                        (typeof dividing.image === 'string' &&
+                          dividing.image.includes('example'))
+                          ? '/images/notFound_image.png'
+                          : dividing.image
+                      }
+                      className="absolute inset-0 h-full w-full rounded-lg object-cover transition-transform duration-300 hover:scale-110"
+                    />
+                  </div>
                 </div>
                 <div className="flex flex-col gap-2">
                   <CardTitle

--- a/src/app/sharing/components/SharingListSection.tsx
+++ b/src/app/sharing/components/SharingListSection.tsx
@@ -8,7 +8,6 @@ import {
   CardImage,
   CardSubtitle,
   CardTitle,
-  // BookmarkButton,
   Line,
   StatusTag,
 } from '@/components';
@@ -16,7 +15,6 @@ import { MapPin } from 'lucide-react';
 import { DividingMeetingsType } from '@/types/meetingsType';
 import { timeFormatter } from '@/utils';
 
-// import { useBookmark } from '@/hooks';
 import { useInfiniteScrollTrigger } from '@/hooks/useScroll';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getDividingListApi } from '@/apis/meetings/getDividingListApi';
@@ -31,7 +29,6 @@ export const SharingListSection = ({
   initialDividingList: DividingMeetingsType | null;
 }) => {
   const router = useRouter();
-  // const { handleBookmark } = useBookmark();
   const { isBottom } = useInfiniteScrollTrigger();
 
   const {
@@ -115,16 +112,6 @@ export const SharingListSection = ({
                     status={dividing.status}
                     className="absolute top-3 left-3 z-10"
                   />
-                  {/* <BookmarkButton
-                  className="absolute top-4 right-0"
-                  liked={dividing.bookmarked}
-                  onChange={() =>
-                    handleBookmark(
-                      dividing.groupId.toString(),
-                      dividing.bookmarked,
-                    )
-                  }
-                /> */}
                   <CardImage
                     alt="기본 카드"
                     src={

--- a/src/app/sharing/register/page.tsx
+++ b/src/app/sharing/register/page.tsx
@@ -7,13 +7,15 @@ import { GET_MODEL_DISTRICT_OPTIONS } from '@/constants/locations';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
-import ImageUploadForm from '../../../components/marketplace/registerModal/imageLoader';
+import ImageUploadForm from '@/components/marketplace/registerModal/imageLoader';
 import { useMutation } from '@tanstack/react-query';
 import { dividingRegisterApi } from '@/apis';
 import { ApiResponse } from '@/types/common';
 import { useToast } from '@/components/Atoms';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useUserLocation } from '@/hooks';
+import { useEffect } from 'react';
 
 const DIVIDING_PRODUCT_TYPE_OPTIONS = [
   { value: 'FRESH', label: '신선식품' },
@@ -84,6 +86,7 @@ const dividingFormSchema = z.object({
 type DividingFormData = z.infer<typeof dividingFormSchema>;
 
 export default function DividingRegisterPage() {
+  const { userLocation, hasLocation } = useUserLocation();
   const {
     register,
     handleSubmit,
@@ -110,6 +113,15 @@ export default function DividingRegisterPage() {
   });
   const { success, error } = useToast();
   const router = useRouter();
+
+  useEffect(() => {
+    if (hasLocation && userLocation) {
+      setValue('location.province', userLocation.province || '');
+      setValue('location.city', userLocation.city || '');
+      setValue('location.district', userLocation.district || '');
+      setValue('location.detail', userLocation.detail || '');
+    }
+  }, [hasLocation, userLocation, setValue]);
 
   const { mutate: dividingRegister } = useMutation({
     mutationFn: async (formatData: DividingFormData) => {

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -6,7 +6,6 @@ import {
   CardFooter,
   CardSubtitle,
   CardTitle,
-  // BookmarkButton,
   Line,
   StatusTag,
 } from '@/components';
@@ -15,7 +14,6 @@ import { timeFormatter } from '@/utils';
 import { MapPin } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-// import { useBookmark } from '@/hooks';
 import { useEffect } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getShoppingListApi } from '@/apis/meetings/getShoppingListApi';
@@ -30,7 +28,6 @@ export const ShoppingListSection = ({
   initialShoppingList: ShoppingMeetingsType | null;
 }) => {
   const router = useRouter();
-  // const { handleBookmark } = useBookmark();
   const { isBottom } = useInfiniteScrollTrigger();
   const searchParams = useSearchParams();
 
@@ -122,13 +119,6 @@ export const ShoppingListSection = ({
             >
               <StatusTag status={shopping.status} />
               <CardContent className="flex flex-col gap-3">
-                {/* <BookmarkButton
-                  className="absolute top-[4px] right-0"
-                  liked={shopping.bookmarked}
-                  onChange={() =>
-                    handleBookmark(shopping.id.toString(), shopping.bookmarked)
-                  }
-                /> */}
                 <CardTitle
                   className="font-memomentKkukkkuk line-clamp-2"
                   status={shopping.status as 'RECRUITING'}

--- a/src/app/shopping/components/ShoppingListSection.tsx
+++ b/src/app/shopping/components/ShoppingListSection.tsx
@@ -108,7 +108,7 @@ export const ShoppingListSection = ({
 
   return (
     <>
-      <div className="columns-1 gap-4 space-y-4 md:columns-2 md:gap-5 md:space-y-5 xl:columns-4">
+      <div className="columns-1 gap-4 space-y-4 sm:columns-2 md:columns-3 md:gap-5 md:space-y-5 xl:columns-4">
         {shoppingList.pages
           .flatMap((page) => page.content)
           .map((shopping) => (

--- a/src/app/shopping/register/page.tsx
+++ b/src/app/shopping/register/page.tsx
@@ -16,6 +16,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
+import { useUserLocation } from '@/hooks';
+import { useEffect } from 'react';
 
 const shoppingFormSchema = z.object({
   title: z
@@ -61,6 +63,7 @@ const shoppingFormSchema = z.object({
 type ShoppingFormData = z.infer<typeof shoppingFormSchema>;
 
 export default function ShoppingRegisterPage() {
+  const { userLocation, hasLocation } = useUserLocation();
   const {
     register,
     handleSubmit,
@@ -86,6 +89,15 @@ export default function ShoppingRegisterPage() {
   });
   const { success, error } = useToast();
   const router = useRouter();
+
+  useEffect(() => {
+    if (hasLocation && userLocation) {
+      setValue('location.province', userLocation.province || '');
+      setValue('location.city', userLocation.city || '');
+      setValue('location.district', userLocation.district || '');
+      setValue('location.detail', userLocation.detail || '');
+    }
+  }, [hasLocation, userLocation, setValue]);
 
   const { mutate: shoppingRegister } = useMutation({
     mutationFn: async (formData: ShoppingFormData) => {

--- a/src/components/marketplace/applicants/ApplicantsList.tsx
+++ b/src/components/marketplace/applicants/ApplicantsList.tsx
@@ -158,7 +158,7 @@ export const ApplicantsList = ({
 
                     {/* 참여자 강퇴 상태 */}
                     {participant.status === 'KICKED' && (
-                      <div className="text-text-sub2 text-sm">
+                      <div className="text-text-sub2 text-sm font-semibold">
                         강퇴된 참여자
                       </div>
                     )}

--- a/src/components/marketplace/registerModal/SharingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/SharingRegisterForm.tsx
@@ -5,7 +5,7 @@ import {
   GET_MODEL_CITY_OPTIONS,
   GET_MODEL_DISTRICT_OPTIONS,
 } from '@/constants';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { sharingRegisterApi } from '@/apis/meetings/registerApi';
 import {
   useToast,
@@ -21,6 +21,7 @@ import { ApiResponse } from '@/types/common';
 import categories from '@/constants/categories';
 import ImageUploadForm from './imageLoader';
 import RegisterModalHeader from './RegisterModalHeader';
+import { useUserLocation } from '@/hooks';
 
 interface SharingRegisterFormProps {
   handleClose: () => void;
@@ -29,6 +30,7 @@ interface SharingRegisterFormProps {
 export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
   const { success, error } = useToast();
   const router = useRouter();
+  const { userLocation, hasLocation } = useUserLocation();
 
   const [formData, setFormData] = useState({
     title: '',
@@ -43,6 +45,18 @@ export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
     productType: '',
     imageUrls: [] as File[],
   });
+
+  useEffect(() => {
+    if (hasLocation && userLocation) {
+      setFormData((prev) => ({
+        ...prev,
+        province: userLocation.province || '',
+        city: userLocation.city || '',
+        district: userLocation.district || '',
+        detail: userLocation.detail || '',
+      }));
+    }
+  }, [hasLocation, userLocation]);
 
   const isValid = useMemo(() => {
     return (

--- a/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
@@ -6,7 +6,7 @@ import {
   GET_MODEL_DISTRICT_OPTIONS,
   CAPACITY_OPTIONS,
 } from '@/constants';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { shoppingRegisterApi } from '@/apis/meetings/registerApi';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -20,6 +20,7 @@ import {
   Label,
 } from '@/components/Atoms';
 import { Dropdown } from '@/components/Molecules';
+import { useUserLocation } from '@/hooks';
 
 interface ShoppingRegisterFormProps {
   handleClose: () => void;
@@ -30,6 +31,7 @@ export function ShoppingRegisterForm({
 }: ShoppingRegisterFormProps) {
   const { success, error } = useToast();
   const router = useRouter();
+  const { userLocation, hasLocation } = useUserLocation();
 
   const [formData, setFormData] = useState({
     title: '',
@@ -43,6 +45,20 @@ export function ShoppingRegisterForm({
     description: '',
     capacity: 0,
   });
+
+  useEffect(() => {
+    if (hasLocation && userLocation) {
+      setFormData((prev) => ({
+        ...prev,
+        location: {
+          province: userLocation.province || '',
+          city: userLocation.city || '',
+          district: userLocation.district || '',
+          detail: userLocation.detail || '',
+        },
+      }));
+    }
+  }, [hasLocation, userLocation]);
 
   const isValid = useMemo(() => {
     return (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useBookmark';
 export * from './useClickOutside';
 export * from './useReviewAnimation';
 export * from './useReviewStats';
+export * from './useUserLocation';

--- a/src/hooks/useUserLocation.ts
+++ b/src/hooks/useUserLocation.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from '@/apis/auth/hooks/authStore';
+
+export const useUserLocation = () => {
+  const { userLocation } = useAuthStore();
+
+  return {
+    userLocation,
+    hasLocation: !!(
+      userLocation.province &&
+      userLocation.city &&
+      userLocation.district
+    ),
+  };
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #284


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 소분/장보기 모임 등록시 내 주소 불러오는 기능 구현
- 북마크 코드 삭제
- 장보기 목록 반응형시 한 줄에 카드 갯수 수정
  - 기존: 4 >> 2 >> 1
  - 변경: 4 >> 3>> 2 >> 1
- 강퇴된 참여자 폰트 두껍게
- 소분 카드 목록 이미지 비율을 가로3 세로2로 통일
- 마이페이지 카드 목록에 테두리 및 hover 효과 적용

## 📸 스크린샷 (선택)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.