### PR TITLE
fix: 댓글 관련 함수를 서버액션 -> 탄스택쿼리로 변경

### DIFF
--- a/src/apis/comment/createComment.ts
+++ b/src/apis/comment/createComment.ts
@@ -1,4 +1,5 @@
 import { axiosInstance } from '../axiosInstance';
+import { commentSchema } from '@/schemas/commentSchema';
 
 export const createCommentApi = async ({
   meetingId,
@@ -9,6 +10,12 @@ export const createCommentApi = async ({
   content: string;
   secret: boolean;
 }) => {
+  const validated = commentSchema.safeParse({ comment: content });
+
+  if (!validated.success) {
+    throw new Error(validated.error.issues[0].message);
+  }
+
   try {
     const response = await axiosInstance.post(
       `/v1/meetings/${meetingId}/comments`,

--- a/src/apis/comment/createComment.ts
+++ b/src/apis/comment/createComment.ts
@@ -1,0 +1,25 @@
+import { axiosInstance } from '../axiosInstance';
+
+export const createCommentApi = async ({
+  meetingId,
+  content,
+  secret,
+}: {
+  meetingId: string;
+  content: string;
+  secret: boolean;
+}) => {
+  try {
+    const response = await axiosInstance.post(
+      `/v1/meetings/${meetingId}/comments`,
+      {
+        content,
+        secret,
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('댓글 생성 실패', error);
+    throw error;
+  }
+};

--- a/src/apis/comment/createReply.ts
+++ b/src/apis/comment/createReply.ts
@@ -1,4 +1,5 @@
 import { axiosInstance } from '../axiosInstance';
+import { commentSchema } from '@/schemas/commentSchema';
 
 export const createReplyApi = async ({
   meetingId,
@@ -11,6 +12,12 @@ export const createReplyApi = async ({
   content: string;
   secret: boolean;
 }) => {
+  const validated = commentSchema.safeParse({ comment: content });
+
+  if (!validated.success) {
+    throw new Error(validated.error.issues[0].message);
+  }
+
   try {
     const response = await axiosInstance.post(
       `/v1/meetings/${meetingId}/comments/${commentId}/replies`,

--- a/src/apis/comment/createReply.ts
+++ b/src/apis/comment/createReply.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '../axiosInstance';
+
+export const createReplyApi = async ({
+  meetingId,
+  commentId,
+  content,
+  secret,
+}: {
+  meetingId: string;
+  commentId: string;
+  content: string;
+  secret: boolean;
+}) => {
+  try {
+    const response = await axiosInstance.post(
+      `/v1/meetings/${meetingId}/comments/${commentId}/replies`,
+      {
+        content,
+        secret,
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('대댓글 생성 실패', error);
+    throw error;
+  }
+};

--- a/src/apis/comment/deleteComment.ts
+++ b/src/apis/comment/deleteComment.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '../axiosInstance';
+
+export const deleteCommentApi = async ({
+  meetingId,
+  commentId,
+}: {
+  meetingId: string;
+  commentId: string;
+}) => {
+  try {
+    const response = await axiosInstance.delete(
+      `/v1/meetings/${meetingId}/comments/${commentId}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('댓글 삭제 실패', error);
+    throw error;
+  }
+};

--- a/src/apis/comment/getCommentCount.ts
+++ b/src/apis/comment/getCommentCount.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '../axiosInstance';
+
+export const getCommentCountApi = async (meetingId: string) => {
+  try {
+    const response = await axiosInstance.get(
+      `/v1/meetings/${meetingId}/comments?page=0&size=1`,
+    );
+    return response.data.data.totalElements;
+  } catch (error) {
+    console.error('댓글 개수 조회 실패', error);
+    throw error;
+  }
+};

--- a/src/apis/comment/updateComment.ts
+++ b/src/apis/comment/updateComment.ts
@@ -1,4 +1,5 @@
 import { axiosInstance } from '../axiosInstance';
+import { commentSchema } from '@/schemas/commentSchema';
 
 export const updateCommentApi = async ({
   meetingId,
@@ -11,6 +12,12 @@ export const updateCommentApi = async ({
   content: string;
   secret: boolean;
 }) => {
+  const validated = commentSchema.safeParse({ comment: content });
+
+  if (!validated.success) {
+    throw new Error(validated.error.issues[0].message);
+  }
+
   try {
     const response = await axiosInstance.put(
       `/v1/meetings/${meetingId}/comments/${commentId}`,

--- a/src/apis/comment/updateComment.ts
+++ b/src/apis/comment/updateComment.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '../axiosInstance';
+
+export const updateCommentApi = async ({
+  meetingId,
+  commentId,
+  content,
+  secret,
+}: {
+  meetingId: string;
+  commentId: string;
+  content: string;
+  secret: boolean;
+}) => {
+  try {
+    const response = await axiosInstance.put(
+      `/v1/meetings/${meetingId}/comments/${commentId}`,
+      {
+        content,
+        secret,
+      },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('댓글 수정 실패', error);
+    throw error;
+  }
+};

--- a/src/app/(main)/sharing/[id]/page.tsx
+++ b/src/app/(main)/sharing/[id]/page.tsx
@@ -149,20 +149,22 @@ export default async function SharingDetailPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ sortType: 'RECENT' | 'OLDEST' }>;
 }) {
-  const id = (await params).id;
-  const sortType = (await searchParams).sortType;
+  const meetingId = (await params).id;
+  const sortType = (await searchParams).sortType || 'OLDEST';
   // 소분하기 모임 상세 데이터 조회
   const meetingDetail = await getMeetingDetail({
-    id,
+    id: meetingId,
   });
 
   const userInfo = await getUserInfo();
 
   const isAuthor = meetingDetail?.user.userId === userInfo?.id;
 
-  const commentsList = await getComments({ id, sortType });
+  const commentsList = await getComments({ id: meetingId, sortType });
 
-  const participants = isAuthor ? await getParticipants({ meetingId: id }) : [];
+  const participants = isAuthor
+    ? await getParticipants({ meetingId: meetingId })
+    : [];
 
   return (
     <section>

--- a/src/components/marketplace/ActionMenu/CommentActionMenu.tsx
+++ b/src/components/marketplace/ActionMenu/CommentActionMenu.tsx
@@ -53,6 +53,9 @@ export const CommentActionMenu = ({
       queryClient.invalidateQueries({
         queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['commentCount', meetingId],
+      });
     },
     onError: () => {
       error(TOAST_FAILURE_MESSAGE.DELETE_COMMENT);

--- a/src/components/marketplace/ActionMenu/CommentActionMenu.tsx
+++ b/src/components/marketplace/ActionMenu/CommentActionMenu.tsx
@@ -51,7 +51,7 @@ export const CommentActionMenu = ({
       deleteModal.close();
       onClose?.();
       queryClient.invalidateQueries({
-        queryKey: ['commentList', meetingId, sortType],
+        queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
     },
     onError: () => {

--- a/src/components/marketplace/comment/CommentCountContainer.tsx
+++ b/src/components/marketplace/comment/CommentCountContainer.tsx
@@ -3,26 +3,32 @@
 import { getCommentCountApi } from '@/apis/comment/getCommentCount';
 import { DateFilter } from '@/components/Atoms';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter, useParams } from 'next/navigation';
+import { useParams, useSearchParams, usePathname } from 'next/navigation';
 
 export const CommentCountContainer = ({
   initialCommentCount,
 }: {
   initialCommentCount: number;
 }) => {
-  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const meetingId = useParams<{ id: string }>().id;
 
   const { data: commentCount } = useQuery({
     queryKey: ['commentCount', meetingId],
     queryFn: () => getCommentCountApi(meetingId),
     initialData: initialCommentCount,
-    retry: 1,
-    retryDelay: 1000,
   });
   const handleSortTypeChange = (value: 'RECENT' | 'OLDEST') => {
     const formattedValue = value === 'OLDEST' ? 'RECENT' : 'OLDEST';
-    router.push(`?sortType=${formattedValue}`, { scroll: false });
+
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set('sortType', formattedValue);
+
+    const newUrl = `${pathname}?${params.toString()}`;
+
+    window.history.replaceState({}, '', newUrl);
   };
 
   return (

--- a/src/components/marketplace/comment/CommentCountContainer.tsx
+++ b/src/components/marketplace/comment/CommentCountContainer.tsx
@@ -1,15 +1,25 @@
 'use client';
 
+import { getCommentCountApi } from '@/apis/comment/getCommentCount';
 import { DateFilter } from '@/components/Atoms';
-import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter, useParams } from 'next/navigation';
 
 export const CommentCountContainer = ({
-  commentCount,
+  initialCommentCount,
 }: {
-  commentCount: number;
+  initialCommentCount: number;
 }) => {
   const router = useRouter();
+  const meetingId = useParams<{ id: string }>().id;
 
+  const { data: commentCount } = useQuery({
+    queryKey: ['commentCount', meetingId],
+    queryFn: () => getCommentCountApi(meetingId),
+    initialData: initialCommentCount,
+    retry: 1,
+    retryDelay: 1000,
+  });
   const handleSortTypeChange = (value: 'RECENT' | 'OLDEST') => {
     const formattedValue = value === 'OLDEST' ? 'RECENT' : 'OLDEST';
     router.push(`?sortType=${formattedValue}`, { scroll: false });
@@ -18,7 +28,7 @@ export const CommentCountContainer = ({
   return (
     <div className="mb-6 flex items-center justify-between">
       <p className="font-memomentKkukkkuk">
-        댓글 <span className="text-primary">{commentCount}</span>개
+        댓글 <span className="text-primary">{commentCount ?? 0}</span>개
       </p>
       <DateFilter onChange={(value) => handleSortTypeChange(value)} />
     </div>

--- a/src/components/marketplace/comment/CommentInputContainer.tsx
+++ b/src/components/marketplace/comment/CommentInputContainer.tsx
@@ -31,6 +31,9 @@ export const CommentInputContainer = ({
       queryClient.invalidateQueries({
         queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['commentCount', meetingId],
+      });
     },
     onError: (err: Error) => {
       error(err.message || '댓글 작성에 실패했습니다.');

--- a/src/components/marketplace/comment/CommentInputContainer.tsx
+++ b/src/components/marketplace/comment/CommentInputContainer.tsx
@@ -27,10 +27,10 @@ export const CommentInputContainer = ({
     onSuccess: (data) => {
       const sortType = searchParams.get('sortType');
 
-      queryClient.invalidateQueries({
-        queryKey: ['commentList', meetingId, sortType],
-      });
       success(data.message);
+      queryClient.invalidateQueries({
+        queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
+      });
     },
     onError: (err: Error) => {
       error(err.message || '댓글 작성에 실패했습니다.');

--- a/src/components/marketplace/comment/CommentInputContainer.tsx
+++ b/src/components/marketplace/comment/CommentInputContainer.tsx
@@ -2,11 +2,11 @@
 
 import { TextInput } from '@/components';
 import { Button } from '@/components';
-import { createComment } from '@/action/commentAction';
-import { useActionState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useToast } from '@/components/Atoms';
 import { cn } from '@/utils/cn';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createCommentApi } from '@/apis/comment/createComment';
 
 export const CommentInputContainer = ({
   status,
@@ -14,27 +14,42 @@ export const CommentInputContainer = ({
   status: 'RECRUITING' | 'COMPLETED' | 'CLOSED';
 }) => {
   const meetingId = useParams<{ id: string }>().id;
-  const [state, formAction] = useActionState(createComment, null);
   const { success, error } = useToast();
+  const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
 
-  useEffect(() => {
-    if (state) {
-      // 성공 메시지인지 에러 메시지인지 판단
-      if (typeof state === 'string' && state.includes('작성')) {
-        success(state);
-      } else if (typeof state === 'string') {
-        // 에러 메시지
-        error(state);
-      } else if (state === null) {
-        // 서버 에러
-        error('댓글 작성에 실패했습니다.');
-      }
-    }
-  }, [state]);
+  const { mutate: createComment } = useMutation({
+    mutationFn: (data: {
+      meetingId: string;
+      content: string;
+      secret: boolean;
+    }) => createCommentApi(data),
+    onSuccess: (data) => {
+      const sortType = searchParams.get('sortType');
+
+      queryClient.invalidateQueries({
+        queryKey: ['commentList', meetingId, sortType],
+      });
+      success(data.message);
+    },
+    onError: (err: Error) => {
+      error(err.message || '댓글 작성에 실패했습니다.');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    const meetingId = formData.get('meetingId') as string;
+    const content = formData.get('comment') as string;
+    const secret = Boolean(formData.get('secret'));
+    createComment({ meetingId, content, secret });
+    (e.target as HTMLFormElement).reset();
+  };
 
   return (
     <div className="mb-6">
-      <form action={formAction} className="flex items-center gap-2">
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
         <input name="meetingId" hidden readOnly value={meetingId} />
         <div className="relative flex-1">
           <TextInput

--- a/src/components/marketplace/comment/CommentItem.tsx
+++ b/src/components/marketplace/comment/CommentItem.tsx
@@ -68,7 +68,7 @@ export const CommentItem = ({
       success(data.message || '댓글 수정을 완료했어요.');
       handleCancelClick();
       queryClient.invalidateQueries({
-        queryKey: ['commentList', meetingId, sortType],
+        queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
     },
     onError: (err: Error) => {

--- a/src/components/marketplace/comment/CommentItem.tsx
+++ b/src/components/marketplace/comment/CommentItem.tsx
@@ -7,10 +7,12 @@ import { Button, ProfileImg, ProfilePopover, TextInput } from '@/components';
 import { CommentActionMenu } from '@/components/marketplace/ActionMenu/CommentActionMenu';
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
-import { updateComment } from '@/action/commentAction';
+import { updateCommentApi } from '@/apis/comment/updateComment';
 import { useToast } from '@/components/Atoms';
 import { useAuthStore } from '@/apis/auth/hooks/authStore';
 import { usePopoverReview } from '@/hooks/usePopoverReview';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
 
 export const CommentItem = ({
   isAuthor,
@@ -24,6 +26,9 @@ export const CommentItem = ({
   const meetingId = useParams<{ id: string }>().id;
   const { success, error } = useToast();
   const [currentComment, setCurrentComment] = useState(comment.content);
+  const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
+  const sortType = searchParams.get('sortType');
 
   const handleEditClick = () => {
     setIsEditing((prev) => !prev);
@@ -52,6 +57,25 @@ export const CommentItem = ({
       }))
     : [];
 
+  const { mutate: updateComment } = useMutation({
+    mutationFn: (data: {
+      meetingId: string;
+      commentId: string;
+      content: string;
+      secret: boolean;
+    }) => updateCommentApi(data),
+    onSuccess: (data) => {
+      success(data.message || '댓글 수정을 완료했어요.');
+      handleCancelClick();
+      queryClient.invalidateQueries({
+        queryKey: ['commentList', meetingId, sortType],
+      });
+    },
+    onError: (err: Error) => {
+      error(err.message || '댓글 수정에 실패했어요.');
+    },
+  });
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.target as HTMLFormElement);
@@ -59,13 +83,15 @@ export const CommentItem = ({
       (comment as CommentType)?.commentId?.toString() ||
       (comment as ReplyType)?.replyId?.toString() ||
       '';
-    const response = await updateComment(null, formData, commentId, meetingId);
-    if (response) {
-      success(response.message || '댓글 수정을 완료했어요.');
-      handleCancelClick();
-    } else {
-      error(response.message || '댓글 수정에 실패했어요.');
-    }
+    const content = formData.get('comment') as string;
+    const secret = Boolean(formData.get('secret'));
+
+    updateComment({
+      meetingId,
+      commentId,
+      content,
+      secret,
+    });
   };
   return (
     <div>

--- a/src/components/marketplace/comment/CommentItem.tsx
+++ b/src/components/marketplace/comment/CommentItem.tsx
@@ -70,6 +70,9 @@ export const CommentItem = ({
       queryClient.invalidateQueries({
         queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['commentCount', meetingId],
+      });
     },
     onError: (err: Error) => {
       error(err.message || '댓글 수정에 실패했어요.');

--- a/src/components/marketplace/comment/CommentListContainer.tsx
+++ b/src/components/marketplace/comment/CommentListContainer.tsx
@@ -50,7 +50,7 @@ export const CommentListContainer = ({
       success(data.message);
       handleCloseReply();
       queryClient.invalidateQueries({
-        queryKey: ['commentList', meetingId, sortType],
+        queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
     },
     onError: (err: Error) => {
@@ -64,7 +64,7 @@ export const CommentListContainer = ({
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ['commentList', meetingId, sortType],
+    queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
     queryFn: async ({ pageParam }) => {
       const urlParams = new URLSearchParams();
 

--- a/src/components/marketplace/comment/CommentListContainer.tsx
+++ b/src/components/marketplace/comment/CommentListContainer.tsx
@@ -52,6 +52,9 @@ export const CommentListContainer = ({
       queryClient.invalidateQueries({
         queryKey: ['commentList', meetingId, sortType || 'OLDEST'],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['commentCount', meetingId],
+      });
     },
     onError: (err: Error) => {
       error(err.message || '대댓글 작성에 실패했습니다.');

--- a/src/components/marketplace/comment/CommentSection.tsx
+++ b/src/components/marketplace/comment/CommentSection.tsx
@@ -15,7 +15,9 @@ export const CommentSection = ({
   return (
     <div className="mt-8 w-full">
       {/* 댓글 헤더 */}
-      <CommentCountContainer commentCount={commentsList!.totalElements} />
+      <CommentCountContainer
+        initialCommentCount={commentsList!.totalElements}
+      />
 
       {/* 댓글 입력 영역 */}
       <CommentInputContainer status={status} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #308 

## 📝 작업 내용
- 댓글 입력, 수정, 삭제가 바로 적용되지 않는 문제 해결
- 댓글 입력, 수정, 삭제에 관련된 서버 액션들을 탄스택쿼리 함수로 변경
- 댓글 필터를 눌렀을 때 새로고침이 되는 문제 해결
- 댓글의 갯수가 최신으로 반영되지 않는 문제 해결
