### PR TITLE
fix: 장보기 목록 내 세로 정렬 >> 가로 정렬

### DIFF
--- a/src/components/Atoms/DateFilter/DateFilter.tsx
+++ b/src/components/Atoms/DateFilter/DateFilter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowDown, ArrowUp } from 'lucide-react';
+import { cn } from '@/utils/cn';
 import { useState, memo } from 'react';
 
 export interface DateFilterProps {
@@ -25,7 +26,14 @@ export const DateFilter = memo(({ className, onChange }: DateFilterProps) => {
     <div
       data-testid="date-filter-button"
       onClick={() => handleOptionChange()}
-      className={`border-gray-10 flex h-10 cursor-pointer items-center justify-center gap-0.5 rounded-lg border p-1.5 select-none md:justify-between md:gap-1 md:px-3 md:py-2 ${className}`}
+      className={cn(
+        'flex h-10 items-center justify-center md:justify-between',
+        'cursor-pointer select-none',
+        'gap-0.5 md:gap-1',
+        'p-1.5 md:px-3 md:py-2',
+        'border-gray-10 rounded-lg border',
+        className,
+      )}
     >
       <div className="flex items-center gap-[1px]">
         <ArrowUp


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #314


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- tailwind 정렬 스타일 가독성 있게 변경 ([코드 리뷰 반영](https://github.com/SoboonSoboon/soboon-client/pull/313#discussion_r2476358576))
- 장보기 목록 내 세로 정렬 >> 가로 정렬
  - 지금 레이아웃을 유지하면서, 최신글이 가장 위쪽에 오도록 로직을 수정했습니다. (feat. AI)
  - 원리는
    - 처음 렌더링 때 화면 너비로 columnCount(1/2/3/4)를 계산해 설정
    - 창 너비가 바뀌면 columnCount를 다시 계산해 업데이트
    - columnCount가 변해 리렌더될 때, 아이템→컬럼 분배는 useMemo로 메모이즈되어 필요한 순간에만 다시 계산

## 📸 스크린샷 (선택)

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/ea596810-feb4-4446-af5d-7786d19ee9af" />

<img width="968" height="1031" alt="image" src="https://github.com/user-attachments/assets/d756ef3a-b2d2-42db-af11-7cfaf675f221" />

<img width="761" height="1031" alt="image" src="https://github.com/user-attachments/assets/2a21394d-fb30-4fa4-b99e-a480970a309c" />


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.