### PR TITLE
fix: 소분하기 수정 페이지 내 이미지 불러오는 기능 수정 및 매직넘버 상수화

### DIFF
--- a/src/app/(main)/sharing/components/UpdateDividingForm.tsx
+++ b/src/app/(main)/sharing/components/UpdateDividingForm.tsx
@@ -28,14 +28,28 @@ const DIVIDING_PRODUCT_TYPE_OPTIONS = [
   { value: 'ETC', label: '기타' },
 ];
 
+const FORM_VALIDATION = {
+  MIN_CAPACITY: 2,
+  MAX_CAPACITY: 5,
+  MIN_LOCATION_DETAIL_LENGTH: 3,
+  MAX_LOCATION_DETAIL_LENGTH: 50,
+  MAX_IMAGE_COUNT: 10,
+  MIN_DESCRIPTION_LENGTH: 10,
+  MAX_DESCRIPTION_LENGTH: 500,
+} as const;
+
 const dividingFormSchema = z.object({
   productType: z.string().min(1, { message: '제품 카테고리를 선택해주세요.' }),
   itemName: z.string().min(1, { message: '품목 이름을 입력해주세요.' }),
   capacity: z
     .number()
     .min(1, { message: '모집 인원을 선택해주세요.' })
-    .min(2, { message: '모집 인원은 2명 이상이어야 합니다.' })
-    .max(5, { message: '모집 인원은 5명 이하로 입력해주세요.' }),
+    .min(FORM_VALIDATION.MIN_CAPACITY, {
+      message: `모집 인원은 ${FORM_VALIDATION.MIN_CAPACITY}명 이상이어야 합니다.`,
+    })
+    .max(FORM_VALIDATION.MAX_CAPACITY, {
+      message: `모집 인원은 ${FORM_VALIDATION.MAX_CAPACITY}명 이하로 입력해주세요.`,
+    }),
   location: z.object({
     province: z.string().min(1, { message: '주소를 선택해주세요.' }),
     city: z.string().min(1, { message: '주소를 선택해주세요.' }),
@@ -43,16 +57,24 @@ const dividingFormSchema = z.object({
     detail: z
       .string()
       .min(1, { message: '상세 주소를 입력해주세요.' })
-      .min(3, { message: '상세 주소는 3자 이상 입력해주세요.' })
-      .max(50, { message: '상세 주소는 50자 이하로 입력해주세요.' }),
+      .min(FORM_VALIDATION.MIN_LOCATION_DETAIL_LENGTH, {
+        message: `상세 주소는 ${FORM_VALIDATION.MIN_LOCATION_DETAIL_LENGTH}자 이상 입력해주세요.`,
+      })
+      .max(FORM_VALIDATION.MAX_LOCATION_DETAIL_LENGTH, {
+        message: `상세 주소는 ${FORM_VALIDATION.MAX_LOCATION_DETAIL_LENGTH}자 이하로 입력해주세요.`,
+      }),
   }),
-  imageUrls: z
-    .array(z.string())
-    .max(10, { message: '이미지는 최대 10장까지만 추가할 수 있습니다.' }),
+  imageUrls: z.array(z.string()).max(FORM_VALIDATION.MAX_IMAGE_COUNT, {
+    message: `이미지는 최대 ${FORM_VALIDATION.MAX_IMAGE_COUNT}장까지만 추가할 수 있습니다.`,
+  }),
   description: z
     .string()
-    .min(10, { message: '상세 설명은 10자 이상 입력해주세요.' })
-    .max(500, { message: '상세 설명은 500자 이하로 입력해주세요.' }),
+    .min(FORM_VALIDATION.MIN_DESCRIPTION_LENGTH, {
+      message: `상세 설명은 ${FORM_VALIDATION.MIN_DESCRIPTION_LENGTH}자 이상 입력해주세요.`,
+    })
+    .max(FORM_VALIDATION.MAX_DESCRIPTION_LENGTH, {
+      message: `상세 설명은 ${FORM_VALIDATION.MAX_DESCRIPTION_LENGTH}자 이하로 입력해주세요.`,
+    }),
 });
 
 type DividingFormData = z.infer<typeof dividingFormSchema>;
@@ -320,7 +342,7 @@ export function UpdateDividingForm({
             imageUrls={watch('imageUrls')}
             onChange={(imageUrls: string[]) => setValue('imageUrls', imageUrls)}
             validation={{
-              maxFiles: 10,
+              maxFiles: FORM_VALIDATION.MAX_IMAGE_COUNT,
               maxFileSize: 10 * 1024 * 1024,
               allowedTypes: [
                 'image/jpeg',

--- a/src/app/(main)/sharing/components/index.ts
+++ b/src/app/(main)/sharing/components/index.ts
@@ -2,3 +2,4 @@ export * from './SharingListSection';
 export * from './FilterSection';
 export * from './SearchSection';
 export * from './FilterBottomSheet';
+export * from './UpdateDividingForm';

--- a/src/components/marketplace/index.ts
+++ b/src/components/marketplace/index.ts
@@ -6,3 +6,4 @@ export { DetailAside } from '@/components/marketplace/DetailAside/DetailAside';
 export { ShoppingMeetingRegisterModal } from '@/components/marketplace/registerModal/MeetingRegisterModal';
 export { MeetingActionMenu } from '@/components/marketplace/ActionMenu/MeetingActionMenu';
 export { IntroSection } from '@/components/marketplace/IntroSection';
+export { ImageUploadUrlForm } from '@/components/marketplace/registerModal/ImageUploadUrlForm';

--- a/src/components/marketplace/registerModal/ImageUploadUrlForm.tsx
+++ b/src/components/marketplace/registerModal/ImageUploadUrlForm.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { Button, TextInput } from '@/components';
+import { imageUploader } from '@/utils/imageUploader';
+import { XIcon } from 'lucide-react';
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+
+interface ValidationOptions {
+  maxFiles?: number;
+  maxFileSize?: number; // bytes
+  allowedTypes?: string[];
+}
+
+interface ImageUploadUrlFormProps {
+  imageUrls: string[];
+  onChange: (urls: string[]) => void;
+  validation?: ValidationOptions;
+  onUploadStart?: () => void;
+  onUploadComplete?: () => void;
+  onUploadError?: (error: Error) => void;
+}
+
+const DEFAULT_VALIDATION: ValidationOptions = {
+  maxFiles: 10,
+  maxFileSize: 10 * 1024 * 1024, // 10MB
+  allowedTypes: [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+  ],
+};
+
+export function ImageUploadUrlForm({
+  imageUrls,
+  onChange,
+  validation = DEFAULT_VALIDATION,
+  onUploadStart,
+  onUploadComplete,
+  onUploadError,
+}: ImageUploadUrlFormProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const mergedValidation = { ...DEFAULT_VALIDATION, ...validation };
+  const { maxFiles, maxFileSize, allowedTypes } = mergedValidation;
+
+  const validateFiles = (files: File[]): string | null => {
+    // 최대 파일 개수 검증
+    const totalFiles = imageUrls.length + files.length;
+    if (maxFiles && totalFiles > maxFiles) {
+      return `이미지는 최대 ${maxFiles}개까지 업로드할 수 있습니다.`;
+    }
+
+    // 파일 크기 검증
+    const oversizedFile = files.find((file) => file.size > (maxFileSize || 0));
+    if (oversizedFile && maxFileSize) {
+      const sizeMB = Math.round(maxFileSize / (1024 * 1024));
+      return `각 이미지 파일은 ${sizeMB}MB 이하여야 합니다.`;
+    }
+
+    // 파일 타입 검증
+    const invalidTypeFile = files.find(
+      (file) => !allowedTypes?.includes(file.type),
+    );
+    if (invalidTypeFile && allowedTypes) {
+      const typeNames = allowedTypes
+        .map((type) => type.split('/')[1].toUpperCase())
+        .join(', ');
+      return `${typeNames} 이미지 파일만 업로드 가능합니다.`;
+    }
+
+    return null;
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    const newFiles = Array.from(files);
+
+    // 유효성 검사
+    const validationError = validateFiles(newFiles);
+    if (validationError) {
+      alert(validationError);
+      return;
+    }
+
+    try {
+      setIsUploading(true);
+      onUploadStart?.();
+
+      // S3에 이미지 업로드
+      const uploadedUrls = await imageUploader(newFiles);
+
+      // URL 배열 업데이트
+      onChange([...imageUrls, ...uploadedUrls]);
+
+      onUploadComplete?.();
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error('Upload failed');
+      onUploadError?.(err);
+      alert('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsUploading(false);
+      // input 초기화
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    const updatedUrls = imageUrls.filter((_, i) => i !== index);
+    onChange(updatedUrls);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-3">
+        <TextInput
+          placeholder={
+            imageUrls.length > 0
+              ? `${imageUrls.length}/${maxFiles}개 이미지 선택됨`
+              : `이미지를 최대 ${maxFiles}개까지 첨부할 수 있어요.`
+          }
+          readOnly
+          className="flex-1 cursor-pointer focus:border-transparent focus:outline-none"
+          onClick={() => !isUploading && inputRef.current?.click()}
+        />
+
+        <input
+          type="file"
+          accept="image/*"
+          className="hidden"
+          ref={inputRef}
+          onChange={handleFileChange}
+          multiple
+          disabled={isUploading}
+        />
+        <Button
+          variant="outline"
+          label={isUploading ? '업로드 중...' : '파일 찾기'}
+          onClick={() => inputRef.current?.click()}
+          disabled={isUploading || imageUrls.length >= (maxFiles || 10)}
+        />
+      </div>
+
+      {imageUrls.length > 0 && (
+        <div className="overflow-x-auto">
+          <div className="flex min-w-max gap-2.5">
+            {imageUrls.map((url, index) => (
+              <div key={index} className="group relative flex-shrink-0">
+                <Image
+                  src={url}
+                  alt={`미리보기 ${index + 1}`}
+                  className="size-25 rounded-lg object-cover"
+                  width={100}
+                  height={100}
+                />
+                <button
+                  onClick={() => handleRemoveImage(index)}
+                  className="bg-primary absolute top-1.5 right-1.5 cursor-pointer rounded-full p-1 text-white"
+                  disabled={isUploading}
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #319


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 소분하기 수정 페이지 내 이미지 불러오는 기능 수정
  - 파일 타입의 상태관리 방식을 이미지URL 문자열 타입의 상태관리 방식으로 변경 
- 매직넘버 상수화를 통해 중복 최소화 및 관리 포인트 공통화


## 📸 스크린샷 (선택)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.