### PR TITLE
fix: 소분 목록에 item >> title로 필드명 변경

### DIFF
--- a/src/apis/meetings/registerApi.ts
+++ b/src/apis/meetings/registerApi.ts
@@ -19,7 +19,6 @@ export interface ShoppingRegisterData {
 export interface SharingRegisterData {
   title: string;
   description: string;
-  itemName: string;
   price: number;
   capacity: number;
   province: string;
@@ -32,7 +31,6 @@ export interface SharingRegisterData {
 
 export interface DividingRegisterData {
   title?: string;
-  itemName: string;
   capacity: number;
   location: LocationType;
   productType: string;
@@ -64,7 +62,6 @@ const formatSharingRegisterData = async (data: SharingRegisterData) => {
   const formData = {
     title: data.title,
     description: data.description,
-    itemName: data.itemName,
     price: data.price,
     capacity: data.capacity,
     location: {
@@ -84,7 +81,7 @@ export const dividingRegisterApi = async (formatData: DividingRegisterData) => {
   if (formatData.imageUrls.length === 0) {
     const response = await axiosInstance.post('/v1/meetings/dividing', {
       ...formatData,
-      title: '',
+      title: formatData.title,
       price: 0,
     });
     return response.data;
@@ -94,7 +91,7 @@ export const dividingRegisterApi = async (formatData: DividingRegisterData) => {
     );
     const response = await axiosInstance.post('/v1/meetings/dividing', {
       ...formatData,
-      title: '',
+      title: formatData.title,
       price: 0,
       imageUrls: formattedData,
     });

--- a/src/app/(main)/sharing/components/SharingListSection.tsx
+++ b/src/app/(main)/sharing/components/SharingListSection.tsx
@@ -143,7 +143,7 @@ export const SharingListSection = ({
                     className="font-memomentKkukkkuk line-clamp-1"
                     status={dividing.status as 'RECRUITING'}
                   >
-                    {dividing.item}
+                    {dividing.title}
                   </CardTitle>
                   <CardSubtitle className="text-text-sub2 flex items-center gap-1 text-sm">
                     <span>{dividing.user.userName}</span>

--- a/src/app/(main)/sharing/components/UpdateDividingForm.tsx
+++ b/src/app/(main)/sharing/components/UpdateDividingForm.tsx
@@ -40,7 +40,7 @@ const FORM_VALIDATION = {
 
 const dividingFormSchema = z.object({
   productType: z.string().min(1, { message: '제품 카테고리를 선택해주세요.' }),
-  itemName: z.string().min(1, { message: '품목 이름을 입력해주세요.' }),
+  title: z.string().min(1, { message: '품목 이름을 입력해주세요.' }),
   capacity: z
     .number()
     .min(1, { message: '모집 인원을 선택해주세요.' })
@@ -100,7 +100,7 @@ export function UpdateDividingForm({
     resolver: zodResolver(dividingFormSchema),
     defaultValues: {
       productType: '',
-      itemName: '',
+      title: '',
       capacity: 0,
       location: {
         province: '',
@@ -123,7 +123,7 @@ export function UpdateDividingForm({
 
       reset({
         productType: productTypeValue,
-        itemName: meetingDetail.item || '',
+        title: meetingDetail.title || '',
         capacity: meetingDetail.total_member || 0,
         location: {
           province:
@@ -156,7 +156,7 @@ export function UpdateDividingForm({
     mutationFn: async (formatData: DividingFormData) => {
       const requestData = {
         ...formatData,
-        title: '',
+        title: formatData.title,
         price: 0,
         imageUrls: formatData.imageUrls,
       };
@@ -233,14 +233,12 @@ export function UpdateDividingForm({
         )}
         <div className="mt-3">
           <TextInput
-            id="itemName"
+            id="title"
             placeholder="품목 이름을 적어주세요. (ex. 동물복지 유정란 30구)"
-            {...register('itemName')}
+            {...register('title')}
           />
-          {errors.itemName && (
-            <p className="mt-2 text-sm text-red-500">
-              {errors.itemName.message}
-            </p>
+          {errors.title && (
+            <p className="mt-2 text-sm text-red-500">{errors.title.message}</p>
           )}
         </div>
       </div>

--- a/src/app/(main)/sharing/page.tsx
+++ b/src/app/(main)/sharing/page.tsx
@@ -86,7 +86,7 @@ export default async function SharingPage({
     province: (params.province as string) || '',
     city: (params.city as string) || '',
     district: (params.district as string) || '',
-    item: (params.item as string) || '',
+    title: (params.title as string) || '',
     productType: (params.productType as string) || '',
     sortType: (params.sortType as string) || '',
     page: (params.page as string) || '0',

--- a/src/app/(main)/sharing/register/page.tsx
+++ b/src/app/(main)/sharing/register/page.tsx
@@ -29,7 +29,7 @@ const DIVIDING_PRODUCT_TYPE_OPTIONS = [
 
 const dividingFormSchema = z.object({
   productType: z.string().min(1, { message: '제품 카테고리를 선택해주세요.' }),
-  itemName: z
+  title: z
     .string()
     .min(1, { message: '품목 이름을 입력해주세요.' })
     .refine((val: string) => !/<[^>]*>/i.test(val), {
@@ -98,7 +98,7 @@ export default function DividingRegisterPage() {
     resolver: zodResolver(dividingFormSchema),
     defaultValues: {
       productType: '',
-      itemName: '',
+      title: '',
       capacity: 0,
       location: {
         province: '',
@@ -201,13 +201,13 @@ export default function DividingRegisterPage() {
             )}
             <div className="mt-3">
               <TextInput
-                id="itemName"
+                id="title"
                 placeholder="품목 이름을 적어주세요. (ex. 동물복지 유정란 30구)"
-                {...register('itemName')}
+                {...register('title')}
               />
-              {errors.itemName && (
+              {errors.title && (
                 <p className="mt-2 text-sm text-red-500">
-                  {errors.itemName.message}
+                  {errors.title.message}
                 </p>
               )}
             </div>

--- a/src/types/meetingsType.ts
+++ b/src/types/meetingsType.ts
@@ -14,7 +14,6 @@ GET /v1/meetings/{id}
 type MeetingDetailType = {
   id: number;
   title: string;
-  item: string;
   location_dep0: string;
   location_dep1: string;
   location_dep2: string;
@@ -54,7 +53,7 @@ type DeleteMeetingResponseType = ApiResponse<null | string>;
 */
 interface DividingContentType {
   groupId: number;
-  item: string;
+  title: string;
   image: string;
   productType: ProductType;
   location: LocationType;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #334


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 소분하기 필드명 수정 및 삭제
  - Title: 필드가 있었지만 빈값으로 유지되고 있으므로, 해당 필드 삭제
  - Item: 소분하기 타이틀 내용을 담고 있어서, 필드명을 Item >> Title로 변경 


## 📸 스크린샷 (선택)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->


## 💬 리뷰 요구사항 (선택)
###### 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.