### PR TITLE
fix: 모임 등록/수정 라벨 통일성 있게 수정

### DIFF
--- a/src/app/(main)/sharing/components/UpdateDividingForm.tsx
+++ b/src/app/(main)/sharing/components/UpdateDividingForm.tsx
@@ -265,7 +265,7 @@ export function UpdateDividingForm({
 
       <div className="flex flex-col gap-3">
         <Label htmlFor="province" className="font-semibold" required>
-          어디서 만날까요??
+          어디서 만날까요?
         </Label>
         <div className="flex flex-col gap-3 sm:items-center">
           <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-2.5">

--- a/src/app/(main)/sharing/components/UpdateDividingForm.tsx
+++ b/src/app/(main)/sharing/components/UpdateDividingForm.tsx
@@ -246,7 +246,7 @@ export function UpdateDividingForm({
 
       <div className="flex flex-col gap-3">
         <Label htmlFor="capacity" className="font-semibold" required>
-          몇 명을 모을까요?
+          몇 명이 함께하면 좋을까요?
         </Label>
         <Dropdown
           name="capacity"

--- a/src/app/(main)/sharing/components/UpdateDividingForm.tsx
+++ b/src/app/(main)/sharing/components/UpdateDividingForm.tsx
@@ -360,18 +360,15 @@ export function UpdateDividingForm({
 
       <div className="flex flex-col gap-3">
         <Label htmlFor="description" className="font-semibold" required>
-          상세 설명
+          상세 설명을 작성해 주세요.
         </Label>
         <Textarea
           className="min-h-[120px] sm:min-h-[150px] lg:min-h-[173px]"
           id="description"
           {...register('description')}
-          placeholder={`모집 내용을 작성해주세요.
-
-ex)
+          placeholder={`ex) 언제 구매한 제품이예요.
 이런 식으로 나누고 싶어요.
-언제 구매했어요.
-언제 어디서 만나고 싶어요`}
+언제 어디서 만나고 싶어요.`}
         />
         {errors.description && (
           <p className="text-sm text-red-500">{errors.description.message}</p>

--- a/src/app/(main)/sharing/register/page.tsx
+++ b/src/app/(main)/sharing/register/page.tsx
@@ -323,18 +323,15 @@ export default function DividingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="description" className="font-semibold" required>
-              상세 설명
+              상세 설명을 작성해 주세요.
             </Label>
             <Textarea
               className="min-h-[120px] sm:min-h-[150px] lg:min-h-[173px]"
               id="description"
               {...register('description')}
-              placeholder={`모집 내용을 작성해주세요.
-
-ex)
+              placeholder={`ex) 언제 구매한 제품이예요.
 이런 식으로 나누고 싶어요.
-언제 구매했어요.
-언제 어디서 만나고 싶어요`}
+언제 어디서 만나고 싶어요.`}
             />
             {errors.description && (
               <p className="text-sm text-red-500">

--- a/src/app/(main)/sharing/register/page.tsx
+++ b/src/app/(main)/sharing/register/page.tsx
@@ -216,7 +216,7 @@ export default function DividingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="capacity" className="font-semibold" required>
-              몇 명을 모을까요?
+              몇 명이 함께하면 좋을까요?
             </Label>
             <Dropdown
               name="capacity"

--- a/src/app/(main)/sharing/register/page.tsx
+++ b/src/app/(main)/sharing/register/page.tsx
@@ -235,7 +235,7 @@ export default function DividingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="province" className="font-semibold" required>
-              어디서 만날까요??
+              어디서 만날까요?
             </Label>
             <div className="flex flex-col gap-3 sm:items-center">
               <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-2.5">

--- a/src/app/(main)/shopping/components/UpdateShoppingForm.tsx
+++ b/src/app/(main)/shopping/components/UpdateShoppingForm.tsx
@@ -303,17 +303,15 @@ export function UpdateShoppingForm({
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="detail" className="font-semibold" required>
-              모임의 설명 글을 작성해보세요!
+              모임의 설명 글을 작성해 주세요.
             </Label>
             <Textarea
               className="min-h-[120px] sm:min-h-[150px] lg:min-h-[173px]"
               id="description"
               {...register('detail')}
-              placeholder={`모집 내용을 작성해주세요.
-
-ex) 대량 고기를 사서 나누고 싶어요.
+              placeholder={`ex) 대량 고기를 사서 나누고 싶어요.
 그 외 필요한 구매 물품은 개인 구매하셔도 되어요.
-함께 장보기 할 인원은 3명 정도 생각하고 있어요.이번주 토요일인 10월 10일  3시에 만나기로 해요!`}
+이번주 토요일인 10월 10일 오후 3시에 만나기로 해요.`}
             />
             {errors.detail && (
               <p className="text-sm text-red-500">{errors.detail.message}</p>

--- a/src/app/(main)/shopping/register/page.tsx
+++ b/src/app/(main)/shopping/register/page.tsx
@@ -269,17 +269,15 @@ export default function ShoppingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="detail" className="font-semibold" required>
-              모임의 설명 글을 작성해보세요!
+              모임의 설명 글을 작성해 주세요.
             </Label>
             <Textarea
               className="min-h-[120px] sm:min-h-[150px] lg:min-h-[173px]"
               id="description"
               {...register('detail')}
-              placeholder={`모집 내용을 작성해주세요.
-
-ex) 대량 고기를 사서 나누고 싶어요.
+              placeholder={`ex) 대량 고기를 사서 나누고 싶어요.
 그 외 필요한 구매 물품은 개인 구매하셔도 되어요.
-함께 장보기 할 인원은 3명 정도 생각하고 있어요.이번주 토요일인 10월 10일  3시에 만나기로 해요!`}
+이번주 토요일인 10월 10일 오후 3시에 만나기로 해요.`}
             />
             {errors.detail && (
               <p className="text-sm text-red-500">{errors.detail.message}</p>

--- a/src/app/(main)/shopping/register/page.tsx
+++ b/src/app/(main)/shopping/register/page.tsx
@@ -181,7 +181,7 @@ export default function ShoppingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="capacity" className="font-semibold" required>
-              몇 명을 모을까요?
+              몇 명이 함께하면 좋을까요?
             </Label>
             <Dropdown
               name="capacity"

--- a/src/app/(main)/shopping/register/page.tsx
+++ b/src/app/(main)/shopping/register/page.tsx
@@ -200,7 +200,7 @@ export default function ShoppingRegisterPage() {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="province" className="font-semibold" required>
-              어디서 만날까요??
+              어디서 만날까요?
             </Label>
             <div className="flex flex-col gap-3 sm:items-center">
               <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-2.5">

--- a/src/components/marketplace/registerModal/SharingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/SharingRegisterForm.tsx
@@ -221,7 +221,7 @@ export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="description" required>
-              상세 설명
+              상세 설명을 작성해 주세요.
             </Label>
             <Textarea
               className="min-h-[173px]"
@@ -229,12 +229,9 @@ export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
               id="description"
               required
               value={formData.description}
-              placeholder={`모집 내용을 작성해주세요.
-
-ex)
+              placeholder={`ex) 언제 구매한 제품이예요.
 이런 식으로 나누고 싶어요.
-언제 구매했어요.
-언제 어디서 만나고 싶어요`}
+언제 어디서 만나고 싶어요.`}
               onChange={(e) =>
                 setFormData({ ...formData, description: e.target.value })
               }

--- a/src/components/marketplace/registerModal/SharingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/SharingRegisterForm.tsx
@@ -147,7 +147,7 @@ export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="province" required>
-              어디서 만날까요??
+              어디서 만날까요?
             </Label>
             <div className="flex flex-col items-center gap-3">
               <div className="flex w-full items-center gap-2.5">

--- a/src/components/marketplace/registerModal/SharingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/SharingRegisterForm.tsx
@@ -131,7 +131,7 @@ export function SharingRegisterForm({ handleClose }: SharingRegisterFormProps) {
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="capacity" required>
-              몇 명을 모을까요?
+              몇 명이 함께하면 좋을까요?
             </Label>
             <TextInput
               name="capacity"

--- a/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
@@ -142,7 +142,7 @@ export function ShoppingRegisterForm({
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="province" required>
-              어디서 만날까요??
+              어디서 만날까요?
             </Label>
             <div className="flex flex-col items-center gap-3">
               <div className="flex w-full items-center gap-2.5">

--- a/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
@@ -124,7 +124,7 @@ export function ShoppingRegisterForm({
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="capacity" required>
-              몇 명을 모을까요?
+              몇 명이 함께하면 좋을까요?
             </Label>
             <Dropdown
               name="capacity"

--- a/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
+++ b/src/components/marketplace/registerModal/ShoppingRegisterForm.tsx
@@ -221,7 +221,7 @@ export function ShoppingRegisterForm({
 
           <div className="flex flex-col gap-3">
             <Label htmlFor="description" required>
-              모임의 설명 글을 작성해보세요!
+              모임의 설명 글을 작성해 주세요.
             </Label>
             <Textarea
               className="min-h-[173px]"
@@ -229,11 +229,9 @@ export function ShoppingRegisterForm({
               id="detail"
               required
               value={formData.detail}
-              placeholder={`모집 내용을 작성해주세요.
-
-ex) 대량 고기를 사서 나누고 싶어요.
+              placeholder={`ex) 대량 고기를 사서 나누고 싶어요.
 그 외 필요한 구매 물품은 개인 구매하셔도 되어요.
-함께 장보기 할 인원은 3명 정도 생각하고 있어요.이번주 토요일인 10월 10일  3시에 만나기로 해요!`}
+이번주 토요일인 10월 10일 오후 3시에 만나기로 해요.`}
               onChange={(e) =>
                 setFormData({ ...formData, detail: e.target.value })
               }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #374


## 📝 작업 내용
###### 이번 PR에서 작업한 내용을 간략히 설명해 주세요.
- 모임 인원 라벨 수정
- 장보기 라벨 수정
- 소분 모임 라벨 문구 수정
- 다른 라벨처럼 문음표 한 개로 통일
